### PR TITLE
Allow respecting SuppressWarning when checking for def

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 
 group = "com.virtualdogbert"
-version = "1.0.3"
+version = "1.0.4"
 description = "This library provides enterprise level control over Groovy compilation, like static compilation by default."
 
 wrapper {


### PR DESCRIPTION
A suggestion to provide for selectively allowing usage of def where it is unavoidable, without having to disable the def checking entirely.

It could also be expanded to only apply in compiledynamic blocks of code.